### PR TITLE
renamed alert to startIncident for consistency

### DIFF
--- a/router.go
+++ b/router.go
@@ -311,7 +311,7 @@ func verifyHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func alertHandler(w http.ResponseWriter, r *http.Request) {
+func startIncidentHandler(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	alert := struct {
 		IMEI int      `json:"IMEI"`
@@ -526,7 +526,7 @@ func initRoutes() {
 	http.HandleFunc("/ws", wsHandler)
 	http.HandleFunc("/register", regHandler)
 	http.HandleFunc("/verify", verifyHandler)
-	http.HandleFunc("/alert", alertHandler)
+	http.HandleFunc("/startIncident", startIncidentHandler)
 	http.HandleFunc("/location", locationUpdateHandler)
 	http.HandleFunc("/userStatus", userStatusHandler)
 	http.HandleFunc("/deleteAccount", deleteAccountHandler)


### PR DESCRIPTION
resolves issue #22 
changed the name of the alertHandler to be more consistent with the rest of the system