### PR TITLE
verify endpoint now takes firebase_id

### DIFF
--- a/db/db_init.sql
+++ b/db/db_init.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS users (
 	last_name           VARCHAR(20),
 	phone_number        VARCHAR(16) UNIQUE,
 	current_status      user_status,
- 	api_token           VARCHAR(16)
+ 	api_token           VARCHAR(16),
+ 	firebase_id			VARCHAR(255)
 );
 
 CREATE TABLE IF NOT EXISTS temp_users (


### PR DESCRIPTION
/verify now takes a third parameter, "firebase_id", which is stored/updated along with other user info in the verifyHandler